### PR TITLE
Release version 0.1.4

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -48,6 +48,20 @@ jobs:
         with:
           node-version: ${{ env.PUBLISHING_NODE_VERSION }}
           registry-url: https://npm.pkg.github.com/
+      - name: Insert repository owner as scope into package name
+        run: |
+          node <<EOF
+          const fs = require('fs').promises;
+          fs.readFile('package.json', 'utf8').then((data) => JSON.parse(data)).then((json) => {
+              json.name = '@$(echo "$GITHUB_REPOSITORY" | sed 's/\/.\+//')/' + json.name;
+              console.info('Package name changed to %s', json.name);
+              return fs.writeFile('package.json', JSON.stringify(json), 'utf8');
+          }).catch(error => {
+              console.error(error);
+              process.exit(1);
+          });
+          EOF
+
       - run: npm ci
       - run: npm publish
         env:

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 test/
 test-lib/
 nbproject/
+.github/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merge-stream-in-chunks",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Merge several output streams minimizing data shuffling between the streams producing output in parallel",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* Exclude GitHub CI configuration files from the package
* Dynamically inject repository's owner as scope into the package name when publishing to GPR