### PR TITLE
Support creating new intake stream for a merged stream without immediately piping into it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "merge-stream-in-chunks",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merge-stream-in-chunks",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "Merge several output streams minimizing data shuffling between the streams producing output in parallel",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Update `MergedStream.add` method:
* Make the `source` parameter optional and pipe from the `source` to the
  created intake only when `source` parameter is provided
* Register `on('pipe')` event handler for the created intake stream in
  order set up errors forwarding once external code is ready to pipe
  data through the intake